### PR TITLE
Make icon appear as a circle instead of an oval

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -10,7 +10,9 @@
 
 .panelItem {
     color: #ccc;
-    width: 15px;
-    height: 15px;
+    width: 24px;
+    height: 18px;
     border-radius: 5px;
+    margin-top: 2px;
+    margin-bottom: 2px;
 }


### PR DESCRIPTION
Those changes make the icon appear as it should on my Ubuntu 20.04: an "i" in the middle of a nice circle instead of vertically stretched oval.