### PR TITLE
support for GNOME 40,41,42.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,6 @@
  */
 const St = imports.gi.St; //Gobject-Introspection https://developer.gnome.org/gobject/stable/
 const Main = imports.ui.main; //Main.layoutManager.monitor https://developer.gnome.org/gtk3/stable/
-const Tweener = imports.tweener.tweener;
 
 // The dimming is achieved by inserting a label with null text object and with an alpha channel that
 // covers the whole screen. The text, being null, is not display, but the alpha channel remains; thus, achieving dimming. 
@@ -29,7 +28,7 @@ function handleIconClick() {
         // update in monitor
         update();
     } else {
-	reset();
+        reset();
     }
 }
 
@@ -62,8 +61,6 @@ function init() {
     button = new St.Bin({ style_class: 'panel-button', 
                           reactive: true,
                           can_focus: true,
-                          x_expand: true,
-                          y_expand: false,
                           track_hover: true });
 
     //usr/share/icons/gnome/scalable/actions/system-run-symbolic.svg

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,10 @@
     "3.12.2",
     "3.18",
     "3.18.5",
-    "3.26.2"
+    "3.26.2",
+    "40",
+    "41",
+    "42"
   ],
   "url": "https://github.com/orschiro/adjust-brightness-icon",
   "uuid": "adjust.brightness.icon@orschiro.gmail.com",


### PR DESCRIPTION
just upgraded Ubuntu from 20.04, to 22.04.
Bumped GNOME version in Ubuntu 22.04 now is 42.5.

There is version of the extension which is working on my Ubuntu 22.04 laptop.
Backword compatibility not tested.